### PR TITLE
chore: use @types/vscode@1.73.0 as specified in engines.vscode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@commitlint/cli": "^18.6.1",
         "@commitlint/config-conventional": "^18.6.2",
         "@types/node": "18.x",
-        "@types/vscode": "^1.86.0",
+        "@types/vscode": "^1.73.0",
         "@typescript-eslint/eslint-plugin": "^6.19.1",
         "@typescript-eslint/parser": "^6.19.1",
         "esbuild": "^0.20.0",
@@ -1043,9 +1043,9 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.86.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.86.0.tgz",
-      "integrity": "sha512-DnIXf2ftWv+9LWOB5OJeIeaLigLHF7fdXF6atfc7X5g2w/wVZBgk0amP7b+ub5xAuW1q7qP5YcFvOcit/DtyCQ==",
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.73.0.tgz",
+      "integrity": "sha512-FhkfF7V3fj7S3WqXu7AxFesBLO3uMkdCPJJPbwyZXezv2xJ6xBWHYM2CmkkbO8wT9Fr3KipwxGGOoQRrYq7mHg==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@commitlint/cli": "^18.6.1",
     "@commitlint/config-conventional": "^18.6.2",
     "@types/node": "18.x",
-    "@types/vscode": "^1.86.0",
+    "@types/vscode": "^1.73.0",
     "@typescript-eslint/eslint-plugin": "^6.19.1",
     "@typescript-eslint/parser": "^6.19.1",
     "esbuild": "^0.20.0",


### PR DESCRIPTION
Downgrade @types/vscode to version used inside `engines.vscode`. Without this change I can't publish extension to marketplace