### PR TITLE
chore: bump to 0.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-hermione",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-hermione",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^18.6.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-hermione",
   "displayName": "Hermione",
   "description": "Integration Hermione with VS Code",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "publisher": "gemini-testing",
   "engines": {
     "vscode": "^1.73.0"


### PR DESCRIPTION
In order to publish new version to vscode marketplace I should bump version in package.json