### PR TITLE
feat: add ability to filter tests by browser name

### DIFF
--- a/src/test-tree/index.ts
+++ b/src/test-tree/index.ts
@@ -221,6 +221,8 @@ export class TestTree extends vscode.Disposable {
                 const browserItem = this._createBrowserTestItem(browserId, testItem);
                 this._browserItems.set(browserItem.id, browserItem);
 
+                browserItem.tags = [...browserItem.tags, new vscode.TestTag(`browser:${browserId}`)];
+
                 TestCaseByBrowser.register(browserItem, testItem);
                 testItem.children.add(browserItem);
             });


### PR DESCRIPTION
## What is done?

Add browser tag for each browser test item inside test tree in sidebar. It gives ability to filter test items using tag like `@browser:chrome`.

I also wanted to add tags to display opened tests, but it turned out that they already exist. User can use `@doc` tag to see only tests in opened file and `@openedFiles` to see tests inside all opened files in editor.

How it looks like:

<img width="371" alt="Screenshot 2024-09-24 at 17 24 20" src="https://github.com/user-attachments/assets/4f959f8e-c3fa-495d-b58a-6012b65afa5b">
